### PR TITLE
Improve performance and remove console warning

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { scanRight, scanTop, scanBottom, scanLeft } from "./scan";
 import { makeNewCanvas, parseOptions } from "./utils";
 
 function trimCanvas(canvas: HTMLCanvasElement, options?: Options) {
-  const context = canvas.getContext("2d")!;
+  const context = canvas.getContext("2d", { willReadFrequently: true })!;
   const { width, height } = canvas;
   const data = context.getImageData(0, 0, width, height).data;
 


### PR DESCRIPTION
This will force the use of a software (instead of hardware accelerated) 2D canvas and can save memory when calling getImageData() frequently.

Source: https://developer.mozilla.org/en-US/docs/Web/API/HTMLCanvasElement/getContext#willreadfrequently